### PR TITLE
Unpublish from cerebro plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "main": "dist/index.js",
   "keywords": [
-    "cerebro",
-    "cerebro-plugin"
+    "cerebro"
   ],
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
I've [added](https://github.com/KELiON/cerebro/pull/109) fix-path globally to Cerebro, so this plugin doesn't make sense anymore and can be removed from plugins list